### PR TITLE
Fix critical npm alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "a8c-chrome-mod-header",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "a8c-chrome-mod-header",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "ISC",
       "devDependencies": {
         "@wordpress/scripts": "^30.9.0"
@@ -5899,9 +5899,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.1.tgz",
+      "integrity": "sha512-0yaL8JdxTknKDILitVpfYfV2Ob6yb3udX/hK97M7I3jOeznBNxQPtVvTUtnhUkyHlxFWyr5Lvknmgzoc7jf+1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9757,13 +9757,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -45,5 +45,9 @@
   "homepage": "https://github.com/Automattic/a8c-chrome-mod-header#readme",
   "devDependencies": {
     "@wordpress/scripts": "^30.9.0"
+  },
+  "overrides": {
+    "basic-ftp": "5.2.1",
+    "form-data": "4.0.4"
   }
 }


### PR DESCRIPTION
## Summary
- Pin vulnerable transitive npm packages with overrides.
- Refresh the npm lockfile so critical alerts for `basic-ftp` and `form-data` resolve.

## Testing
- `npm ci --ignore-scripts`
- `npm audit --json` (`critical: 0`)
- `npm ls basic-ftp form-data --all`
- `npm run build`
- `npm run lint:js`
- `npm run lint:css`
- `npm run check-engines`
- `npm run check-licenses`
- `npm run test:unit`